### PR TITLE
Allow guests to release page locks

### DIFF
--- a/src/main/java/us/calubrecht/lazerwiki/WebSecurityConfig.java
+++ b/src/main/java/us/calubrecht/lazerwiki/WebSecurityConfig.java
@@ -1,20 +1,21 @@
 package us.calubrecht.lazerwiki;
 
 
-import org.springframework.beans.factory.annotation.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
-import org.springframework.security.authentication.*;
+import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.web.SecurityFilterChain;
-import org.springframework.security.web.authentication.*;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.security.web.csrf.CookieCsrfTokenRepository;
 import org.springframework.security.web.csrf.XorCsrfTokenRequestAttributeHandler;
 import org.springframework.security.web.servlet.util.matcher.PathPatternRequestMatcher;
-import org.springframework.security.web.util.matcher.*;
+import org.springframework.security.web.util.matcher.RequestMatcher;
 
 @Configuration
 @EnableWebSecurity
@@ -74,6 +75,7 @@ public class WebSecurityConfig {
                                             getMatcher("/api/page/savePage", HttpMethod.POST),
                                             getMatcher("/api/page/*/savePage", HttpMethod.POST),
                                             getMatcher("/api/page/lock/**", HttpMethod.POST),
+                                            getMatcher("/api/page/releaseLock/**", HttpMethod.POST),
                                             getMatcher("/sitemap.xml", HttpMethod.GET),
                                             // Ignore for CORS requests
                                             getMatcher("/**", HttpMethod.OPTIONS),


### PR DESCRIPTION
## Summary

While looking into issue #108, I noticed that guest users can create page locks when they start editing a page, but the endpoint used to release those locks wasn't accessible to unauthenticated users.

## Changes Made

Added the `/api/page/releaseLock/**` endpoint to the list of publicly accessible routes in `WebSecurityConfig`.

## Why

Since guests are allowed to acquire page locks through `/api/page/lock/**`, they should also be able to release those locks when they cancel editing. Without access to the release endpoint, locks may remain active longer than intended.

Fixes #108
